### PR TITLE
fix controller local middleware load

### DIFF
--- a/src/typings/Controller.ts
+++ b/src/typings/Controller.ts
@@ -33,10 +33,11 @@ export default abstract class Controller {
 
     public setRoutes = (): Router => {
         for (const route of this.routes) {
-            for (const mw of route.localMiddleware) {
-                this.router.use(route.path, mw);
-            }
             try {
+                for (const mw of route.localMiddleware) {
+                    this.router[route.method](route.path, mw);
+                }
+
                 this.router[route.method](route.path, route.handler);
             } catch (err) {
                 console.error('not a valid method');


### PR DESCRIPTION
A fix for that if you want to load a local middleware only for one route in the controller, then it would apply for all the subroutes because of the this.app.use(/*...*/)

Eg:
![image](https://user-images.githubusercontent.com/25752233/169979260-8db115f9-c678-40c3-9d91-59cd66774e10.png)

in this case it would apply the token.verify in the POST route too.

I know it makes no sense in this application, because there is no routing like this, but a little improve i think :)